### PR TITLE
Add prometheus annotations to API and ETL

### DIFF
--- a/charts/isaac-app/templates/api/deployment.yaml
+++ b/charts/isaac-app/templates/api/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       {{- if .Values.api.prometheusExport.enabled }}
       annotations:
         prometheus.io/port: {{ .Values.api.prometheusExport.port }}
+        prometheus.io/path: {{ .Values.api.prometheusExport.path }}
         prometheus.io/scrape: true
       {{- end }}
       labels:

--- a/charts/isaac-app/templates/api/deployment.yaml
+++ b/charts/isaac-app/templates/api/deployment.yaml
@@ -12,9 +12,10 @@ spec:
       {{- include "isaac-app.api.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.api.podAnnotations }}
+      {{- if .Values.api.prometheusExport.enabled }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        prometheus.io/port: {{ .Values.api.prometheusExport.port }}
+        prometheus.io/scrape: true
       {{- end }}
       labels:
         {{- include "isaac-app.api.selectorLabels" . | nindent 8 }}
@@ -35,6 +36,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.api.prometheusExport.enabled }}
+            - name: prometheusExport
+              containerPort: {{ .Values.api.prometheusExport.port }}
+              protocol: TCP
+            {{- end }}
           env:
             - name: SEGUE_CONFIG_LOCATION
               value: /local/data/conf/segue-config.properties

--- a/charts/isaac-app/templates/etl/deployment.yaml
+++ b/charts/isaac-app/templates/etl/deployment.yaml
@@ -12,9 +12,10 @@ spec:
       {{- include "isaac-app.etl.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.etl.podAnnotations }}
+      {{- if .Values.etl.prometheusExport.enabled }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        prometheus.io/port: {{ .Values.etl.prometheusExport.port }}
+        prometheus.io/scrape: true
       {{- end }}
       labels:
         {{- include "isaac-app.etl.selectorLabels" . | nindent 8 }}
@@ -35,6 +36,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.etl.prometheusExport.enabled }}
+            - name: prometheusExport
+              containerPort: {{ .Values.etl.prometheusExport.port }}
+              protocol: TCP
+            {{- end }}
           env:
             - name: SEGUE_CONFIG_LOCATION
               value: /local/data/conf/segue-config.properties

--- a/charts/isaac-app/templates/etl/deployment.yaml
+++ b/charts/isaac-app/templates/etl/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       {{- if .Values.etl.prometheusExport.enabled }}
       annotations:
         prometheus.io/port: {{ .Values.etl.prometheusExport.port }}
+        prometheus.io/path: {{ .Values.etl.prometheusExport.path }}
         prometheus.io/scrape: true
       {{- end }}
       labels:

--- a/charts/isaac-app/values.yaml
+++ b/charts/isaac-app/values.yaml
@@ -63,6 +63,7 @@ api:
     contentRepo: git@github.com:pelotech/rutherford-content.git
   prometheusExport:
     enabled: true
+    path: /
     port: 9966
   podSecurityContext: {}
     # fsGroup: 2000
@@ -120,6 +121,7 @@ etl:
     contentRepo: git@github.com:pelotech/rutherford-content.git
   prometheusExport:
     enabled: true
+    path: /
     port: 9966
   podSecurityContext: {}
     # fsGroup: 2000

--- a/charts/isaac-app/values.yaml
+++ b/charts/isaac-app/values.yaml
@@ -61,7 +61,9 @@ api:
     secretName: isaac-secrets
     sshSecretName: isaac-ssh-key
     contentRepo: git@github.com:pelotech/rutherford-content.git
-  podAnnotations: {}
+  prometheusExport:
+    enabled: true
+    port: 9966
   podSecurityContext: {}
     # fsGroup: 2000
   securityContext: {}
@@ -116,7 +118,9 @@ etl:
     secretName: isaac-secrets
     sshSecretName: isaac-ssh-key
     contentRepo: git@github.com:pelotech/rutherford-content.git
-  podAnnotations: {}
+  prometheusExport:
+    enabled: true
+    port: 9966
   podSecurityContext: {}
     # fsGroup: 2000
   securityContext: {}


### PR DESCRIPTION
These annotations will be used in the Prometheus receiver scrape config for target discovery. 