### PR TITLE
Use git-sync image to sync rutherford content

### DIFF
--- a/charts/isaac-app/Chart.yaml
+++ b/charts/isaac-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/isaac-app/templates/api/deployment.yaml
+++ b/charts/isaac-app/templates/api/deployment.yaml
@@ -26,11 +26,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
+        runAsUser: 999
+        fsGroup: 999
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.api.securityContext | nindent 12 }}
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           ports:
@@ -65,27 +64,48 @@ spec:
             - name: isaac-config
               mountPath: /local/data/conf
             - name: git-content
-              mountPath: /local/data/git-contentstore
-      initContainers:
-        - name: git-cloner
-          image: alpine/git
+              mountPath: /local/data/git
+        - name: git-sync
+          image: registry.k8s.io/git-sync/git-sync:v3.6.2
           args:
-            - clone
-            - -c core.sshCommand=ssh -i /local/data/ssh-key/repo-private-key-rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -F /dev/null
-            - {{ .Values.api.config.contentRepo }}
-            - /local/data/git-contentstore
+            - --repo={{ .Values.api.config.contentRepo }}
+            - --root=/local/data/git
+            - --depth={{ .Values.api.config.contentRepoDepth }}
+            - --wait={{ .Values.api.config.contentRepoWait }}
+            - --ssh
+            - --ssh-key-file=/local/data/ssh-key/repo-private-key-rsa
+            - --ssh-known-hosts=false
+            - --add-user
           volumeMounts:
             - name: isaac-ssh-key
               mountPath: /local/data/ssh-key
             - name: git-content
-              mountPath: /local/data/git-contentstore
+              mountPath: /local/data/git
+      initContainers:
+        - name: git-sync-init
+          image: registry.k8s.io/git-sync/git-sync:v3.6.2
+          args:
+            - --one-time
+            - --repo={{ .Values.api.config.contentRepo }}
+            - --root=/local/data/git
+            - --depth={{ .Values.api.config.contentRepoDepth }}
+            - --wait={{ .Values.api.config.contentRepoWait }}
+            - --ssh
+            - --ssh-key-file=/local/data/ssh-key/repo-private-key-rsa
+            - --ssh-known-hosts=false
+            - --add-user
+          volumeMounts:
+            - name: isaac-ssh-key
+              mountPath: /local/data/ssh-key
+            - name: git-content
+              mountPath: /local/data/git
       volumes:
         - name: isaac-config
           secret:
             secretName: {{ .Values.api.config.secretName }}
         - name: isaac-ssh-key
           secret:
-            defaultMode: 256
+            defaultMode: 0400
             secretName: {{ .Values.api.config.sshSecretName }}
         - name: git-content
           emptyDir: {}

--- a/charts/isaac-app/templates/etl/deployment.yaml
+++ b/charts/isaac-app/templates/etl/deployment.yaml
@@ -20,11 +20,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.etl.podSecurityContext | nindent 8 }}
+        runAsUser: 999
+        fsGroup: 999
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.etl.securityContext | nindent 12 }}
           image: "{{ .Values.etl.image.repository }}:{{ .Values.etl.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.etl.image.pullPolicy }}
           ports:
@@ -49,33 +48,48 @@ spec:
             - name: isaac-config
               mountPath: /local/data/conf
             - name: git-content
-              mountPath: /local/data/git-contentstore
-      initContainers:
-        - name: git-cloner
-          image: alpine/git
+              mountPath: /local/data/git
+        - name: git-sync
+          image: registry.k8s.io/git-sync/git-sync:v3.6.2
           args:
-            - clone
-            - -c core.sshCommand=ssh -i /local/data/ssh-key/repo-private-key-rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -F /dev/null
-            - {{ .Values.etl.config.contentRepo }}
-            - /local/data/git-contentstore
+            - --repo={{ .Values.etl.config.contentRepo }}
+            - --root=/local/data/git
+            - --depth={{ .Values.etl.config.contentRepoDepth }}
+            - --wait={{ .Values.etl.config.contentRepoWait }}
+            - --ssh
+            - --ssh-key-file=/local/data/ssh-key/repo-private-key-rsa
+            - --ssh-known-hosts=false
+            - --add-user
           volumeMounts:
             - name: isaac-ssh-key
               mountPath: /local/data/ssh-key
             - name: git-content
-              mountPath: /local/data/git-contentstore
-        - name: changeowner
-          image: busybox
-          command: [ "sh", "-c", "chown -R 999:999 /content" ]
+              mountPath: /local/data/git
+      initContainers:
+        - name: git-sync-init
+          image: registry.k8s.io/git-sync/git-sync:v3.6.2
+          args:
+            - --one-time
+            - --repo={{ .Values.etl.config.contentRepo }}
+            - --root=/local/data/git
+            - --depth={{ .Values.etl.config.contentRepoDepth }}
+            - --wait={{ .Values.etl.config.contentRepoWait }}
+            - --ssh
+            - --ssh-key-file=/local/data/ssh-key/repo-private-key-rsa
+            - --ssh-known-hosts=false
+            - --add-user
           volumeMounts:
+            - name: isaac-ssh-key
+              mountPath: /local/data/ssh-key
             - name: git-content
-              mountPath: /content
+              mountPath: /local/data/git
       volumes:
         - name: isaac-config
           secret:
             secretName: {{ .Values.etl.config.secretName }}
         - name: isaac-ssh-key
           secret:
-            defaultMode: 256
+            defaultMode: 0400
             secretName: {{ .Values.etl.config.sshSecretName }}
         - name: git-content
           emptyDir: {}

--- a/charts/isaac-app/values.yaml
+++ b/charts/isaac-app/values.yaml
@@ -88,19 +88,12 @@ api:
     secretName: isaac-secrets
     sshSecretName: isaac-ssh-key
     contentRepo: git@github.com:pelotech/rutherford-content.git
+    contentRepoDepth: 1
+    contentRepoWait: 60
   prometheusExport:
     enabled: true
     path: /
     port: 9966
-  podSecurityContext: {}
-    # fsGroup: 2000
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
   service:
     type: ClusterIP
     port: 80
@@ -147,15 +140,8 @@ etl:
     secretName: isaac-secrets
     sshSecretName: isaac-ssh-key
     contentRepo: git@github.com:pelotech/rutherford-content.git
-  podSecurityContext: {}
-    # fsGroup: 2000
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+    contentRepoDepth: 1
+    contentRepoWait: 60
   service:
     type: ClusterIP
     port: 5000


### PR DESCRIPTION
* git-sync image automatically checks for new git references and pulls them if present every 60s
* Used for both initcontainer for initial pull and as a sidecar for further repo updates
* runs as UID 999 (same as the java image's jetty user)